### PR TITLE
Passthrough opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,9 +59,10 @@ function _createConnectionConfig(ports) {
 /**
  * Write a connection file
  * @public
- * @param  {object} [options]                     connection options
- * @param  {number} [options.port]
- * @param  {string} [options.host]
+ * @param  {object} [portFinderOptions]           connection options
+ *                                                see {@link https://github.com/indexzero/node-portfinder/blob/master/lib/portfinder.js }
+ * @param  {number} [portFinderOptions.port]
+ * @param  {string} [portFinderOptions.host]
  * @return {object} configResults
  * @return {object} configResults.config          connectionConfig
  * @return {string} configResults.connectionFile  path to the config file
@@ -153,7 +154,7 @@ function launch(kernelName, specs, spawnOptions) {
     return Promise.reject(new Error(`No spec available for ${kernelName}`));
   }
   const spec = specs[kernelName].spec;
-  return launchSpec(spec, spawnOptions);
+  return launchSpec(spec, {}, spawnOptions);
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function writeConnectionFile(options) {
 
   return new Promise((resolve, reject) => {
     getPorts(5, options, (err, ports) => {
-      if(err) {
+      if (err) {
         reject(err);
       } else {
         // Make sure the kernel runtime dir exists before trying to write the
@@ -85,7 +85,7 @@ function writeConnectionFile(options) {
         const config = _createConnectionConfig(ports);
         const connectionFile = path.join(jp.runtimeDir(), `kernel-${uuid.v4()}.json`);
         jsonfile.writeFile(connectionFile, config, (jsonErr) => {
-          if(jsonErr) {
+          if (jsonErr) {
             reject(jsonErr);
           } else {
             resolve({
@@ -142,11 +142,11 @@ function launchSpec(kernelSpec, options) {
  */
 function launch(kernelName, specs) {
   // Let them pass in a cached specs file
-  if(!specs) {
+  if (!specs) {
     return kernelspecs.findAll()
                       .then((sp) => launch(kernelName, sp));
   }
-  if(!specs[kernelName]) {
+  if (!specs[kernelName]) {
     return Promise.reject(new Error(`No spec available for ${kernelName}`));
   }
   const spec = specs[kernelName].spec;

--- a/index.js
+++ b/index.js
@@ -102,23 +102,25 @@ function writeConnectionFile(options) {
 /**
  * Launch a kernel for a given kernelSpec
  * @public
- * @param  {object}       kernelSpec                   describes a specific
- *                                                     kernel, see the npm
- *                                                     package `kernelspecs`
- * @param  {object}       [options]                    connection options
+ * @param  {object}       kernelSpec      describes a specific
+ *                                        kernel, see the npm
+ *                                        package `kernelspecs`
+ * @param  {object}       [options]       connection options
  * @param  {number}       [options.port]
  * @param  {string}       [options.host]
+ * @param  {object}       [spawnOptions]  options for [child_process.spawn]{@link https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options}
  * @return {object}       spawnResults
  * @return {ChildProcess} spawnResults.spawn           spawned process
  * @return {string}       spawnResults.connectionFile  connection file path
  * @return {object}       spawnResults.config          connectionConfig
+ *
  */
-function launchSpec(kernelSpec, options) {
+function launchSpec(kernelSpec, options, spawnOptions) {
   return writeConnectionFile(options).then((c) => {
     const connectionFile = c.connectionFile;
     const config = c.config;
     const argv = kernelSpec.argv.map(x => x === '{connection_file}' ? connectionFile : x);
-    const runningKernel = child_process.spawn(argv[0], argv.slice(1));
+    const runningKernel = child_process.spawn(argv[0], argv.slice(1), spawnOptions);
     return {
       spawn: runningKernel,
       connectionFile,
@@ -135,22 +137,23 @@ function launchSpec(kernelSpec, options) {
  *                                                     objects to look through.
  *                                                     See the npm package
  *                                                     `kernelspecs`
+ * @param  {object}       [spawnOptions]  options for [child_process.spawn]{@link https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options}
  * @return {object}       spawnResults
  * @return {ChildProcess} spawnResults.spawn           spawned process
  * @return {string}       spawnResults.connectionFile  connection file path
  * @return {object}       spawnResults.config          connectionConfig
  */
-function launch(kernelName, specs) {
+function launch(kernelName, specs, spawnOptions) {
   // Let them pass in a cached specs file
   if (!specs) {
     return kernelspecs.findAll()
-                      .then((sp) => launch(kernelName, sp));
+                      .then((sp) => launch(kernelName, sp, spawnOptions));
   }
   if (!specs[kernelName]) {
     return Promise.reject(new Error(`No spec available for ${kernelName}`));
   }
   const spec = specs[kernelName].spec;
-  return launchSpec(spec);
+  return launchSpec(spec, spawnOptions);
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -66,8 +66,8 @@ function _createConnectionConfig(ports) {
  * @return {object} configResults.config          connectionConfig
  * @return {string} configResults.connectionFile  path to the config file
  */
-function writeConnectionFile(options) {
-  options = options || {};
+function writeConnectionFile(portFinderOptions) {
+  const options = Object.assign({}, portFinderOptions);
   options.port = options.port || 9000;
   options.host = options.host || '127.0.0.1';
 

--- a/index.js
+++ b/index.js
@@ -106,9 +106,10 @@ function writeConnectionFile(portFinderOptions) {
  * @param  {object}       kernelSpec      describes a specific
  *                                        kernel, see the npm
  *                                        package `kernelspecs`
- * @param  {object}       [options]       connection options
- * @param  {number}       [options.port]
- * @param  {string}       [options.host]
+ * @param  {object} [portFinderOptions]           connection options
+ *                                                see {@link https://github.com/indexzero/node-portfinder/blob/master/lib/portfinder.js }
+ * @param  {number} [portFinderOptions.port]
+ * @param  {string} [portFinderOptions.host]
  * @param  {object}       [spawnOptions]  options for [child_process.spawn]{@link https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options}
  * @return {object}       spawnResults
  * @return {ChildProcess} spawnResults.spawn           spawned process
@@ -116,8 +117,8 @@ function writeConnectionFile(portFinderOptions) {
  * @return {object}       spawnResults.config          connectionConfig
  *
  */
-function launchSpec(kernelSpec, options, spawnOptions) {
-  return writeConnectionFile(options).then((c) => {
+function launchSpec(kernelSpec, portFinderOptions, spawnOptions) {
+  return writeConnectionFile(portFinderOptions).then((c) => {
     const connectionFile = c.connectionFile;
     const config = c.config;
     const argv = kernelSpec.argv.map(x => x === '{connection_file}' ? connectionFile : x);


### PR DESCRIPTION
In support of https://github.com/nteract/nteract/issues/261.

I'd really like to revisit this interface at some point, it currently passes through options for portfinder and child_process, not sure if we want it restricted at all.
