### PR TITLE
Accept spawnOptions first, specs after

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,10 +106,6 @@ function writeConnectionFile(portFinderOptions) {
  * @param  {object}       kernelSpec      describes a specific
  *                                        kernel, see the npm
  *                                        package `kernelspecs`
- * @param  {object} [portFinderOptions]           connection options
- *                                                see {@link https://github.com/indexzero/node-portfinder/blob/master/lib/portfinder.js }
- * @param  {number} [portFinderOptions.port]
- * @param  {string} [portFinderOptions.host]
  * @param  {object}       [spawnOptions]  options for [child_process.spawn]{@link https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options}
  * @return {object}       spawnResults
  * @return {ChildProcess} spawnResults.spawn           spawned process
@@ -117,8 +113,8 @@ function writeConnectionFile(portFinderOptions) {
  * @return {object}       spawnResults.config          connectionConfig
  *
  */
-function launchSpec(kernelSpec, portFinderOptions, spawnOptions) {
-  return writeConnectionFile(portFinderOptions).then((c) => {
+function launchSpec(kernelSpec, spawnOptions) {
+  return writeConnectionFile().then((c) => {
     const connectionFile = c.connectionFile;
     const config = c.config;
     const argv = kernelSpec.argv.map(x => x === '{connection_file}' ? connectionFile : x);
@@ -145,21 +141,19 @@ function launchSpec(kernelSpec, portFinderOptions, spawnOptions) {
  * @return {string}       spawnResults.connectionFile  connection file path
  * @return {object}       spawnResults.config          connectionConfig
  */
-function launch(kernelName, specs, spawnOptions) {
+function launch(kernelName, spawnOptions, specs) {
   // Let them pass in a cached specs file
   if (!specs) {
     return kernelspecs.findAll()
-                      .then((sp) => launch(kernelName, sp, spawnOptions));
+                      .then((sp) => launch(kernelName, spawnOptions, sp));
   }
   if (!specs[kernelName]) {
     return Promise.reject(new Error(`No spec available for ${kernelName}`));
   }
   const spec = specs[kernelName].spec;
-  return launchSpec(spec, {}, spawnOptions);
+  return launchSpec(spec, spawnOptions);
 }
 
 module.exports = {
   launch,
-  launchSpec,
-  writeConnectionFile,
 };


### PR DESCRIPTION
This reduces our API surface down to only `launch` which can be used like so:
## Pass in the kernel name

``` js
p = launch('python3')
```
## Options for the child_process spawn

``` js
p = launch('python3', { cwd: '/' })
```
## Pass in the direct kernel spec

``` js
p = launch('python3', { cwd: '/' }, [list of kernel specs])
```

After merging this, we'll need to make a major release. I'm not worried about supporting backwards compatibility with this fairly new package solely because all uses of it are the `launch(kernelName)` variety.
