### PR TITLE
return the kernelspec, to pass through launch

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ function launchSpec(kernelSpec, spawnOptions) {
       spawn: runningKernel,
       connectionFile,
       config,
+      kernelSpec
     };
   });
 }


### PR DESCRIPTION
At least in nteract/nteract, we've been using the name without the kernelspec (via `launch`) and actually need this information for the notebook metadata. This exposes it for us to use.
