### PR TITLE
Bump uuid@3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "kernelspecs": "^1.0.0",
     "mkdirp": "^0.5.1",
     "portfinder": "^1.0.7",
-    "uuid": "^2.0.1"
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This makes the uuid version consistent with nteract, jmp, and Hydrogen.