### PR TITLE
Options defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ env:
     - secure: JeyqTluw8Dtr6MYVEfuVw/gvmJ/1Q55qts7+ncGIsZRJ1ptwNPAF4xaKnEYtXIAb+ZDx1HvEEtuFbRcTsVMrWKep7GNV+w7CQKVrzfWaffGF0ttw3y98/NBbBG0EI7UmeF3TjUdGH5c8Tzt4wASvT3EFEas2k3eZhl7eprAdGlyXuDHgNUUcHUhoMLtRlW+t7QyZMaA2G3GjAVHL9giy7tvXnvb34r/D5BrGVC5oFYyDblKi6vvk2bE/Bgb+WNznlt+oj2tvxR76zBBj/xQoT31SrQ03DvrnJ0rv+Qg7oi0fx/whaNk0vM51iWsqZqak21MTPks9u+S4J5qkKmcJvgcoCPhxxPtUuCstEvzeitgWZUJRYKeX47dBRE085DVUQ9lvLKa69Ct0BVQemaV0wWIUzBJ3tZBSOtUTm5kmC2Mi0MtsPDSSv3h68CLCKv32UqSy1NZ0rDzDkP3w+mH5ee0GYHeJBhUa939twZDZEnh6VmiqrWiy22VyXNQ1T7sOtQw59ATtIvGeN08WB4ymODvWSzSH/uB+n9bRbBKJwvkT3LJ6K7BRjavrW0xUTDCBApjisbTV4b0Nt0Y4T0amdQr0Lxyx45QLNkViL3dNrkeayhSSRBqfpRZZAC0pSegIL+OmTCQCaIzsy8EFK9csKEx6yJ11htbJLyfmQ97G/x4=
 
 before_install:
-  - pip install jupyter_console --user
-  - jupyter kernelspec install-self --user
+  - pip install -U pip --user
+  - python -m pip install ipykernel==4.6.1 IPython==5.3.0 --user
+  - python -m ipykernel install --user
 
 after_success:
   - bash ./travis_after_success.sh

--- a/index.js
+++ b/index.js
@@ -22,17 +22,17 @@
 /**
  *
  */
-const path = require('path');
+const path = require("path");
 
-const kernelspecs = require('kernelspecs');
-const jp = require('jupyter-paths');
+const kernelspecs = require("kernelspecs");
+const jp = require("jupyter-paths");
 
-const uuid = require('uuid');
-const getPorts = require('portfinder').getPorts;
-const jsonfile = require('jsonfile');
+const uuid = require("uuid");
+const getPorts = require("portfinder").getPorts;
+const jsonfile = require("jsonfile");
 
-const child_process = require('child_process');
-const mkdirp = require('mkdirp');
+const child_process = require("child_process");
+const mkdirp = require("mkdirp");
 
 /**
  * Creates a connectionConfig object given an array of ports
@@ -45,14 +45,14 @@ function _createConnectionConfig(ports) {
   return {
     version: 5,
     key: uuid.v4(),
-    signature_scheme: 'hmac-sha256',
-    transport: 'tcp',
-    ip: '127.0.0.1',
+    signature_scheme: "hmac-sha256",
+    transport: "tcp",
+    ip: "127.0.0.1",
     hb_port: ports[0],
     control_port: ports[1],
     shell_port: ports[2],
     stdin_port: ports[3],
-    iopub_port: ports[4],
+    iopub_port: ports[4]
   };
 }
 
@@ -70,7 +70,7 @@ function _createConnectionConfig(ports) {
 function writeConnectionFile(portFinderOptions) {
   const options = Object.assign({}, portFinderOptions);
   options.port = options.port || 9000;
-  options.host = options.host || '127.0.0.1';
+  options.host = options.host || "127.0.0.1";
 
   return new Promise((resolve, reject) => {
     getPorts(5, options, (err, ports) => {
@@ -84,14 +84,17 @@ function writeConnectionFile(portFinderOptions) {
 
         // Write the kernel connection file.
         const config = _createConnectionConfig(ports);
-        const connectionFile = path.join(jp.runtimeDir(), `kernel-${uuid.v4()}.json`);
-        jsonfile.writeFile(connectionFile, config, (jsonErr) => {
+        const connectionFile = path.join(
+          jp.runtimeDir(),
+          `kernel-${uuid.v4()}.json`
+        );
+        jsonfile.writeFile(connectionFile, config, jsonErr => {
           if (jsonErr) {
             reject(jsonErr);
           } else {
             resolve({
               config,
-              connectionFile,
+              connectionFile
             });
           }
         });
@@ -114,13 +117,18 @@ function writeConnectionFile(portFinderOptions) {
  *
  */
 function launchSpec(kernelSpec, spawnOptions) {
-  return writeConnectionFile().then((c) => {
+  return writeConnectionFile().then(c => {
     const connectionFile = c.connectionFile;
     const config = c.config;
-    const argv = kernelSpec.argv.map(x => x === '{connection_file}' ? connectionFile : x);
+    const argv = kernelSpec.argv.map(
+      x => (x === "{connection_file}" ? connectionFile : x)
+    );
     const env = Object.assign({}, process.env, kernelSpec.env);
-    const runningKernel = child_process.spawn(argv[0], argv.slice(1),
-      Object.assign({}, { 'env': env}, spawnOptions));
+    const runningKernel = child_process.spawn(
+      argv[0],
+      argv.slice(1),
+      Object.assign({}, { env: env }, spawnOptions)
+    );
     return {
       spawn: runningKernel,
       connectionFile,
@@ -147,8 +155,9 @@ function launchSpec(kernelSpec, spawnOptions) {
 function launch(kernelName, spawnOptions, specs) {
   // Let them pass in a cached specs file
   if (!specs) {
-    return kernelspecs.findAll()
-                      .then((sp) => launch(kernelName, spawnOptions, sp));
+    return kernelspecs
+      .findAll()
+      .then(sp => launch(kernelName, spawnOptions, sp));
   }
   if (!specs[kernelName]) {
     return Promise.reject(new Error(`No spec available for ${kernelName}`));
@@ -159,5 +168,5 @@ function launch(kernelName, spawnOptions, specs) {
 
 module.exports = {
   launch,
-  launchSpec,
+  launchSpec
 };

--- a/index.js
+++ b/index.js
@@ -123,11 +123,22 @@ function launchSpec(kernelSpec, spawnOptions) {
     const argv = kernelSpec.argv.map(
       x => (x === "{connection_file}" ? connectionFile : x)
     );
+
+    const defaultSpawnOptions = {
+      stdio: "ignore"
+    };
     const env = Object.assign({}, process.env, kernelSpec.env);
+    const fullSpawnOptions = Object.assign(
+      {},
+      defaultSpawnOptions,
+      { env: env },
+      spawnOptions
+    );
+
     const runningKernel = child_process.spawn(
       argv[0],
       argv.slice(1),
-      Object.assign({}, { env: env }, spawnOptions)
+      fullSpawnOptions
     );
     return {
       spawn: runningKernel,


### PR DESCRIPTION
Spawn options are now folded into a set of default options, using `Object.assign`
(not a full merge).

Note: this is a breaking change, particularly for Hydrogen which was providing
"loose" stdout and stderr as notification messages in Atom (I love having this
when I'm working with Spark in Hydrogen).

Fixes #24

-------------------

Check out commit 	ce657d3, as the first commit is primarily there to bring us inline with the rest of our code bases (using prettier).