### PR TITLE
Cope with {connection_file} being a substring

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ function launchSpecFromConnectionInfo(
   spawnOptions
 ) {
   const argv = kernelSpec.argv.map(
-    x => (x === "{connection_file}" ? connectionFile : x)
+    x => (x.replace("{connection_file}", connectionFile))
   );
 
   const defaultSpawnOptions = {


### PR DESCRIPTION
Jupyter allows kernelspecs to contain arguments with ``{connection_file}`` as a
substring, e.g. `` `wslpath {connection_file}` ``. This commit uses ``string.replace()`` to match that behaviour.  

Previously ``{connection_file}`` had to be an argument on its own in ``argv``. That's not a big deal, except if you're trying to do something niche, like start a kernel in Windows Subsystem Linux, that requires the filepath to be converted.  This fixes #42.  