### PR TITLE
merge all env variables instead of replacing the env object

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,21 +159,24 @@ function launchSpecFromConnectionInfo(
   connectionFile,
   spawnOptions
 ) {
-  const argv = kernelSpec.argv.map(
-    x => (x.replace("{connection_file}", connectionFile))
+  const argv = kernelSpec.argv.map(x =>
+    x.replace("{connection_file}", connectionFile)
   );
 
   const defaultSpawnOptions = {
     stdio: "ignore",
     cleanupConnectionFile: true
   };
-  const env = Object.assign({}, process.env, kernelSpec.env);
-  const fullSpawnOptions = Object.assign(
+
+  const fullSpawnOptions = Object.assign({}, defaultSpawnOptions, spawnOptions);
+
+  // TODO: see if this interferes with what execa assigns to the env option
+  // issue #40: merge all env variables without replacing env by spawnOptions.env
+  fullSpawnOptions.env = Object.assign(
     {},
-    defaultSpawnOptions,
-    // TODO: see if this interferes with what execa assigns to the env option
-    { env: env },
-    spawnOptions
+    process.env,
+    kernelSpec.env,
+    (spawnOptions || {}).env
   );
 
   const runningKernel = execa(argv[0], argv.slice(1), fullSpawnOptions);

--- a/index.js
+++ b/index.js
@@ -138,6 +138,29 @@ function launchSpec(kernelSpec, spawnOptions) {
 }
 
 /**
+ * This computes the SpawnOptions environment.
+ * It merges all environment variables in a specific precedence ordering.
+ * The process itself, then the kernelspecs's env from kernel.json,
+ * and then any overrides passed to spawnteract's spawnOptions.env configuration.
+ *
+ * related issue #40: merge all env variables without replacing env by spawnOptions.env
+ *
+ * @param  {object}       kernelSpec
+ * @param  {object}       spawnOptions
+ *
+ * @return {object}       computed environment variables
+ */
+
+function computeSpawnOptionsEnv(kernelSpec, spawnOptions) {
+  return Object.assign(
+    {},
+    process.env,
+    (kernelSpec.spec || {}).env,
+    (spawnOptions || {}).env
+  );
+}
+
+/**
  * Launch a kernel for a given kernelSpec and connection info
  * @public
  * @param  {object}       kernelSpec      describes a specific
@@ -171,13 +194,7 @@ function launchSpecFromConnectionInfo(
   const fullSpawnOptions = Object.assign({}, defaultSpawnOptions, spawnOptions);
 
   // TODO: see if this interferes with what execa assigns to the env option
-  // issue #40: merge all env variables without replacing env by spawnOptions.env
-  fullSpawnOptions.env = Object.assign(
-    {},
-    process.env,
-    kernelSpec.env,
-    (spawnOptions || {}).env
-  );
+  fullSpawnOptions.env = computeSpawnOptionsEnv(kernelSpec, spawnOptions);
 
   const runningKernel = execa(argv[0], argv.slice(1), fullSpawnOptions);
 
@@ -225,5 +242,6 @@ function launch(kernelName, spawnOptions, specs) {
 module.exports = {
   launch,
   launchSpec,
-  launchSpecFromConnectionInfo
+  launchSpecFromConnectionInfo,
+  computeSpawnOptionsEnv // for testing
 };

--- a/test/spawn_spec.js
+++ b/test/spawn_spec.js
@@ -2,6 +2,7 @@ const expect = require("chai").expect;
 const fs = require("fs");
 
 const launch = require("../").launch;
+const computeSpawnOptionsEnv = require("../").computeSpawnOptionsEnv;
 const kernelspecs = require("kernelspecs");
 
 function cleanup(connectionFile) {
@@ -12,6 +13,21 @@ function cleanup(connectionFile) {
     return;
   }
 }
+
+// don't launch this, just for testing
+const fakeKernelspec = {
+  name: "myPython3",
+  files: ["/usr/local/share/kernels/python3/kernel.json"],
+  resources_dir: "/usr/local/share/kernels/python3",
+  spec: {
+    display_name: "My Python 3",
+    argv: ["/usr/bin/python3", "-m", "ipykernel", "-f", "{connection_file}"],
+    language: "python",
+    env: {
+      MyVar: "123"
+    }
+  }
+};
 
 describe("launch", () => {
   let spawnResult;
@@ -63,12 +79,39 @@ describe("launch", () => {
       .then(kernels => {
         const kernel = kernels.python2 || kernels.python3;
         kernelName = kernel.name;
-        return launch(kernelName, {env: {FOOBAR:"BAZ"}});
-      }).then(c => {
-       // console.log(c.spawn.pid);
-       // TODO write an actual test to see if FOOBAR is set -- at least we know it doesn't throw if env is set
-       c.spawn.kill();
-       done();
-    })
-  })
+        return launch(kernelName, { env: { FOOBAR: "BAZ" } });
+      })
+      .then(c => {
+        // console.log(c.spawn.pid);
+        c.spawn.kill();
+        done();
+      });
+  });
+
+  it("computes spawn options environment variables correctly", done => {
+    kernelspecs.findAll().then(kernels => {
+      const kernelSpec = kernels.python3 || kernels.python2;
+      const so1 = { env: { FOOBAR: "BAZ" } };
+
+      const env1 = computeSpawnOptionsEnv(kernelSpec, so1);
+      expect(env1.FOOBAR == "BAZ").to.be.true;
+      expect(env1.PATH.length > 0).to.be.true;
+
+      const env2 = computeSpawnOptionsEnv(kernelSpec, {});
+      expect(env2.PWD.indexOf("spawnteract") >= 0).to.be.true;
+      expect(env2.PATH.length > 0).to.be.true;
+
+      // testing merging
+      const env3 = computeSpawnOptionsEnv(fakeKernelspec, so1);
+      expect(env3.FOOBAR == "BAZ").to.be.true;
+      expect(env3.MyVar == "123").to.be.true;
+
+      // also test overriding
+      const so2 = { env: { MyVar: "99" } };
+      const env4 = computeSpawnOptionsEnv(fakeKernelspec, so2);
+      expect(env4.MyVar == "99").to.be.true;
+
+      done();
+    });
+  });
 });

--- a/test/spawn_spec.js
+++ b/test/spawn_spec.js
@@ -56,4 +56,19 @@ describe("launch", () => {
       done();
     }, 100);
   });
+
+  it("processes env variables", done => {
+    kernelspecs
+      .findAll()
+      .then(kernels => {
+        const kernel = kernels.python2 || kernels.python3;
+        kernelName = kernel.name;
+        return launch(kernelName, {env: {FOOBAR:"BAZ"}});
+      }).then(c => {
+       // console.log(c.spawn.pid);
+       // TODO write an actual test to see if FOOBAR is set -- at least we know it doesn't throw if env is set
+       c.spawn.kill();
+       done();
+    })
+  })
 });


### PR DESCRIPTION
this fixes issue #40. the test is not really a test, but at least we know this doesn't throw an error.

I successfully tested this with the code we use at cocalc. in particular, we explicitly set env vars like

```
opts.env.PLOTLY_RENDERER = "colab";
[...]
this._kernel = await require("spawnteract").launch(this.name, opts);
```

while we still want to keep env vars specified in the `kernel.json` file, e.g.

```
{
  "display_name": "MY dev Python 3",
  "argv": [ ... ],
  "env": {
    "FooBar": "BAZ"
  }
}
```

and in the notebook: `os.environ['FooBar']` → `BAZ`